### PR TITLE
:wrench: Fix hostname for sitemap

### DIFF
--- a/book.json
+++ b/book.json
@@ -12,7 +12,7 @@
         "branch": "master"
     },
     "sitemap-general": {
-      "prefix": "https://namingconventions.org/"
+      "prefix": "https://namingconvention.org/"
     },
     "githubcontributors": {
       "githubOwner": "naming-convention",


### PR DESCRIPTION
Fixed the wrong hostname for sitemap from plural to singular