### PR TITLE
Replaced wrong link for gitbook help

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Please follow recommended workflow below:
 1. Please fork this repo and send pull requests.
 2. For minor edits, you edit pages using Github's web-based editor.
 3. For major edits, it will be better to make a pull request or use [gitbook-editor](https://legacy.gitbook.com/editor) on localhost.
-4. It will be useful to check [gitbook help docs](http://help.gitbook.io/). Not all docs may be useful to you.
+4. It will be useful to check [gitbook help docs](https://help.gitbook.com/). Not all docs may be useful to you.
 
 Please feel free to open a [github issue](https://github.com/wpveda/book/issues) if you need more help.
 


### PR DESCRIPTION
Changes made:
File name- CONTRIBUTING.md
https://help.gitbook.io  -> https://help.gitbook.com/