### PR TITLE
Added naming conventions for Python

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -47,4 +47,5 @@
   * [Constant Naming](python/constant-naming.md)
   * [Package Naming](python/file-naming.md)
   * [Exception\( Error \) Naming](python/exception-naming.md)
+  * [Underscore](python/underscore.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,7 +4,7 @@
   * [Contribute Guide](docs/CONTRIBUTING.md)
   * [FAQ](docs/faq.md)
   * [Lexicon](docs/lexicon.md)
-* [C\#](csharp/README.md)
+* [C#](csharp/README.md)
   * [Argument Naming](csharp/argument-naming.md)
   * [Class Naming](csharp/class-naming.md)
   * [Enum Naming](csharp/enum-naming.md)
@@ -46,6 +46,6 @@
   * [Variable Naming](python/variable-naming.md)
   * [Constant Naming](python/constant-naming.md)
   * [Package Naming](python/file-naming.md)
-  * [Exception\( Error \) Naming](python/exception-naming.md)
+  * [Exception( Error ) Naming](python/exception-naming.md)
   * [Underscore](python/underscore.md)
 

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,7 +4,7 @@
   * [Contribute Guide](docs/CONTRIBUTING.md)
   * [FAQ](docs/faq.md)
   * [Lexicon](docs/lexicon.md)
-* [C#](csharp/README.md)
+* [C\#](csharp/README.md)
   * [Argument Naming](csharp/argument-naming.md)
   * [Class Naming](csharp/class-naming.md)
   * [Enum Naming](csharp/enum-naming.md)
@@ -45,3 +45,6 @@
   * [Method Naming](python/method-naming.md)
   * [Variable Naming](python/variable-naming.md)
   * [Constant Naming](python/constant-naming.md)
+  * [Package Naming](python/file-naming.md)
+  * [Exception\( Error \) Naming](python/exception-naming.md)
+

--- a/python/README.md
+++ b/python/README.md
@@ -1,9 +1,31 @@
 # Python Naming Convention
+
 List of covered sections:
+
 * [Class Naming](../python/class-naming.md)
 * [Constant Naming](../python/constant-naming.md)
 * [Method Naming](../python/method-naming.md)
 * [Module Naming](../python/module-naming.md)
 * [Variable Naming](../python/variable-naming.md)
+* [Package Naming](/../python/package-naming.md "Python Package Naming")
+
+#### Summary: {#3164-guidelines-derived-from-guidos-recommendations}
+
+The style guide for python is based on [Guido’s ](https://www.python.org/doc/essays/styleguide/)naming convention recommendations.
+
+| Type | Public | Internal |
+| :--- | :--- | :--- |
+| Packages | `lower_with_under` |  |
+| Modules | `lower_with_under` | `_lower_with_under` |
+| Classes | `CapWords` | `_CapWords` |
+| Exceptions | `CapWords` |  |
+| Functions | `lower_with_under()` | `_lower_with_under()` |
+| Global/Class Constants | `CAPS_WITH_UNDER` | `_CAPS_WITH_UNDER` |
+| Global/Class Variables | `lower_with_under` | `_lower_with_under` |
+| Instance Variables | `lower_with_under` | `_lower_with_under`\(protected\) |
+| Method Names | `lower_with_under()` | `_lower_with_under()`\(protected\) |
+| Function/Method Parameters | `lower_with_under` |  |
+| Local Variables | `lower_with_under` |  |
 
 Missing something? Please contribute here by reading [this guide](../docs/CONTRIBUTING.md).
+

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Python Naming Convention
 
-The style guide for python is based on [Guido’s ](https://www.python.org/doc/essays/styleguide/)naming convention recommendations.
+The style guide for Python is based on [Guido’s ](https://www.python.org/doc/essays/styleguide/)naming convention recommendations.
 
 List of covered sections:
 

--- a/python/README.md
+++ b/python/README.md
@@ -9,8 +9,9 @@ List of covered sections:
 * [Variable Naming](../python/variable-naming.md)
 * [Package Naming](/../python/package-naming.md "Python Package Naming")
 * [Exception Naming](//../python/exception-naming.md)
+* [Underscore](//../python/underscore.md)
 
-#### Summary: {#3164-guidelines-derived-from-guidos-recommendations}
+#### Summary of the above files: {#3164-guidelines-derived-from-guidos-recommendations}
 
 The style guide for python is based on [Guido’s ](https://www.python.org/doc/essays/styleguide/)naming convention recommendations.
 
@@ -23,8 +24,8 @@ The style guide for python is based on [Guido’s ](https://www.python.org/doc/e
 | Functions | `lower_with_under()` | `_lower_with_under()` |
 | Global/Class Constants | `CAPS_WITH_UNDER` | `_CAPS_WITH_UNDER` |
 | Global/Class Variables | `lower_with_under` | `_lower_with_under` |
-| Instance Variables | `lower_with_under` | `_lower_with_under`\(protected\) |
-| Method Names | `lower_with_under()` | `_lower_with_under()`\(protected\) |
+| Instance Variables | `lower_with_under` | \_lower\_with\_under |
+| Method Names | `lower_with_under()` | `_lower_with_under()` |
 | Function/Method Parameters | `lower_with_under` |  |
 | Local Variables | `lower_with_under` |  |
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,7 @@
 # Python Naming Convention
 
+The style guide for python is based on [Guido’s ](https://www.python.org/doc/essays/styleguide/)naming convention recommendations.
+
 List of covered sections:
 
 * [Class Naming](../python/class-naming.md)
@@ -11,9 +13,7 @@ List of covered sections:
 * [Exception Naming](//../python/exception-naming.md)
 * [Underscore](//../python/underscore.md)
 
-#### Summary of the above files: {#3164-guidelines-derived-from-guidos-recommendations}
-
-The style guide for python is based on [Guido’s ](https://www.python.org/doc/essays/styleguide/)naming convention recommendations.
+#### TL;DR {#3164-guidelines-derived-from-guidos-recommendations}
 
 | Type | Public | Internal |
 | :--- | :--- | :--- |

--- a/python/README.md
+++ b/python/README.md
@@ -9,11 +9,11 @@ List of covered sections:
 * [Method Naming](../python/method-naming.md)
 * [Module Naming](../python/module-naming.md)
 * [Variable Naming](../python/variable-naming.md)
-* [Package Naming](/../python/package-naming.md "Python Package Naming")
-* [Exception Naming](//../python/exception-naming.md)
-* [Underscore](//../python/underscore.md)
+* [Package Naming](../python/package-naming.md "Python Package Naming")
+* [Exception Naming](../python/exception-naming.md)
+* [Underscore](../python/underscore.md)
 
-#### TL;DR {#3164-guidelines-derived-from-guidos-recommendations}
+#### TL;DR
 
 | Type | Public | Internal |
 | :--- | :--- | :--- |

--- a/python/README.md
+++ b/python/README.md
@@ -8,6 +8,7 @@ List of covered sections:
 * [Module Naming](../python/module-naming.md)
 * [Variable Naming](../python/variable-naming.md)
 * [Package Naming](/../python/package-naming.md "Python Package Naming")
+* [Exception Naming](//../python/exception-naming.md)
 
 #### Summary: {#3164-guidelines-derived-from-guidos-recommendations}
 

--- a/python/class-naming.md
+++ b/python/class-naming.md
@@ -13,7 +13,7 @@ class Car:
 
 ## Private Class
 
-Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
+Python does not support privacy directly. This naming convention is used as a weak internal use indicator.
 
 * Should follow the above naming conventions
 * Should use a leading underscore \(\_\) to distinguish between "public" and "private" classes

--- a/python/class-naming.md
+++ b/python/class-naming.md
@@ -1,11 +1,27 @@
-# Python Naming Convention > Class Naming
+# Python Naming Convention &gt; Class Naming
 
 ## PascalCase
-- Begin with an uppercase letter
-- Preferably a noun e.g. Car, Bird, MountainBike
-- Avoid acronyms and abbreviations
+
+* Begin with an uppercase letter
+* Preferably a noun e.g. Car, Bird, MountainBike
+* Avoid acronyms and abbreviations
 
 ```python
 class Car:
     ...
 ```
+
+## Private Class
+
+Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
+
+* Should follow the above naming conventions
+* Should use a leading underscore to distinguish between "public" and "private" functions in module
+* For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
+
+```
+class _Car: # private class
+```
+
+
+

--- a/python/class-naming.md
+++ b/python/class-naming.md
@@ -16,7 +16,7 @@ class Car:
 Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
 
 * Should follow the above naming conventions
-* Should use a leading underscore to distinguish between "public" and "private" functions in module
+* Should use a leading underscore \(\_\) to distinguish between "public" and "private" classes
 * For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
 
 ```

--- a/python/class-naming.md
+++ b/python/class-naming.md
@@ -1,4 +1,4 @@
-# Python Naming Convention &gt; Class Naming
+# Python Naming Convention > Class Naming
 
 ## PascalCase
 
@@ -16,7 +16,7 @@ class Car:
 Python does not support privacy directly. This naming convention is used as a weak internal use indicator.
 
 * Should follow the above naming conventions
-* Should use a leading underscore \(\_\) to distinguish between "public" and "private" classes
+* Should use a leading underscore (_) to distinguish between "public" and "private" classes
 * For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
 
 ```

--- a/python/constant-naming.md
+++ b/python/constant-naming.md
@@ -1,9 +1,9 @@
-# Python Naming Convention &gt; Constant Naming
+# Python Naming Convention > Constant Naming
 
-## SCREAMING\_SNAKE\_CASE
+## SCREAMING_SNAKE_CASE
 
 * Should be all uppercase letters e.g. AGE, HEIGHT
-* If the name contains multiple words, it should be separated by underscores \(\_\) such as DAYS\_IN\_MONTH
+* If the name contains multiple words, it should be separated by underscores (_) such as DAYS_IN_MONTH
 * May contain digits but not as the first letter
 
 ```python

--- a/python/constant-naming.md
+++ b/python/constant-naming.md
@@ -1,12 +1,15 @@
-# Python Naming Convention > Constant Naming
+# Python Naming Convention &gt; Constant Naming
 
-## SCREAMING_SNAKE_CASE
-- Should be all uppercase letters e.g. AGE, HEIGHT
-- If the name contains multiple words, it should be separated by underscores (_) such as DAYS_IN_MONTH
-- May contain digits but not as the first letter
+## SCREAMING\_SNAKE\_CASE
+
+* Should be all uppercase letters e.g. AGE, HEIGHT
+* If the name contains multiple words, it should be separated by underscores \(\_\) such as DAYS\_IN\_MONTH
+* May contain digits but not as the first letter
 
 ```python
-class Product:
-    MAX_TEMPERATURE = 36;  
-
+class Product:
+    MAX_TEMPERATURE = 36;
 ```
+
+
+

--- a/python/exception-naming.md
+++ b/python/exception-naming.md
@@ -2,8 +2,8 @@
 
 ## PascalCase
 
-* Exceptions should be classes and hence the class naming convention should be used here.
-* Add a suffix "Error" on your exception names provided the exception is actually an error.
+* Exceptions should be classes and hence the class naming convention should be used.
+* Add a suffix "Error" on your exception names, provided the exception is actually an error.
 * Avoid acronyms and abbreviations
 
 ```python

--- a/python/exception-naming.md
+++ b/python/exception-naming.md
@@ -1,4 +1,4 @@
-# Python Naming Convention &gt; Exception Naming
+# Python Naming Convention > Exception Naming
 
 ## PascalCase
 

--- a/python/exception-naming.md
+++ b/python/exception-naming.md
@@ -1,0 +1,20 @@
+# Python Naming Convention &gt; Exception Naming
+
+## PascalCase
+
+* Exceptions should be classes and hence the class naming convention should be used here.
+* Add a suffix "Error" on your exception names provided the exception is actually an error.
+* Avoid acronyms and abbreviations
+
+```python
+class ElectricCarError(Exception):
+    """Basic exception for errors raised by non electric cars"""
+    def __init__(self, car, type):
+        if type is not "electric":
+            msg = "%s is not an electric car" % car
+        super(ElectricCarError, self).__init__(msg)
+        self.car = car
+```
+
+
+

--- a/python/file-naming.md
+++ b/python/file-naming.md
@@ -1,9 +1,9 @@
-# Python module Convention &gt; Package Naming
+# Python module Convention > Package Naming
 
-## snake\_case
+## snake_case
 
 * Should be in lowercase.
-* If the name contains multiple words, an underscore \(\_\) should separate it.E.g. expression\_engine
+* If the name contains multiple words, an underscore (_) should separate it.E.g. expression_engine
 * The name should resonate with the class or methods inside the module
 
 ```python

--- a/python/file-naming.md
+++ b/python/file-naming.md
@@ -1,0 +1,16 @@
+# Python module Convention &gt; Package Naming
+
+## snake\_case
+
+* Should be in lowercase.
+* If the name contains multiple words, an underscore \(\_\) should separate it.E.g. expression\_engine
+* The name should resonate with the class or methods inside the module
+
+```python
+from math import factorial
+class Car:
+    ...
+```
+
+
+

--- a/python/method-naming.md
+++ b/python/method-naming.md
@@ -1,9 +1,9 @@
-# Python Naming Convention &gt; Method Naming
+# Python Naming Convention > Method Naming
 
-## snake\_case
+## snake_case
 
 * Should be all in lowercase
-* Preferably a verb e.g. get\_car\(\), purchase\(\), book\(\)
+* Preferably a verb e.g. get_car(), purchase(), book()
 * If the name contains multiple words, it should be separated by underscores \(\_\) e.g. get\_json\(\)
 
 ```python
@@ -17,7 +17,7 @@ class Person:
 Python does not support privacy directly. This naming convention is used as a weak internal use indicator.
 
 * Should follow the above naming conventions
-* Should use a leading underscore \(\_\) to distinguish between "public" and "private" functions in a module
+* Should use a leading underscore (_) to distinguish between "public" and "private" functions in a module
 * For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
 
 ```

--- a/python/method-naming.md
+++ b/python/method-naming.md
@@ -12,9 +12,9 @@ class Person:
         return self.height
 ```
 
-## Private Functions/Methods
+## Private Method
 
-Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
+Python does not support privacy directly. This naming convention is used as a weak internal use indicator.
 
 * Should follow the above naming conventions
 * Should use a leading underscore \(\_\) to distinguish between "public" and "private" functions in a module

--- a/python/method-naming.md
+++ b/python/method-naming.md
@@ -1,12 +1,30 @@
-# Python Naming Convention > Method Naming
+# Python Naming Convention &gt; Method Naming
 
-## snake_case
-- Should be all in lowercase
-- Preferably a verb e.g. get_car(), purchase(), book()
-- If the name contains multiple words, it should be separated by underscores (_) e.g. get_json()
+## snake\_case
+
+* Should be all in lowercase
+* Preferably a verb e.g. get\_car\(\), purchase\(\), book\(\)
+* If the name contains multiple words, it should be separated by underscores \(\_\) e.g. get\_json\(\)
 
 ```python
 class Person:
     def get_height(self):
         return self.height
 ```
+
+## Private Functions/Methods
+
+Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
+
+* Should follow the above naming conventions
+* Should use a leading underscore to distinguish between "public" and "private" functions in module
+* For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
+
+```
+class Person:
+    def _foot_to_centimeter(self): # private method
+        return self.height * 30.48
+```
+
+
+

--- a/python/method-naming.md
+++ b/python/method-naming.md
@@ -17,7 +17,7 @@ class Person:
 Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
 
 * Should follow the above naming conventions
-* Should use a leading underscore to distinguish between "public" and "private" functions in module
+* Should use a leading underscore \(\_\) to distinguish between "public" and "private" functions in a module
 * For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
 
 ```

--- a/python/underscore.md
+++ b/python/underscore.md
@@ -1,8 +1,8 @@
-The underscore \(\_\)  has special meaning in Python.
+The underscore (_)  has special meaning in Python.
 
 ### For ignoring values:
 
-If you do not need a specific value\(s\) while unpacking an object, just assign the value\(s\) to an underscore.
+If you do not need a specific value(s) while unpacking an object, just assign the value(s) to an underscore.
 
 ```
 x, _, y = (1, 2, 3)
@@ -19,11 +19,11 @@ for _, val in list_of_tuples: # [(1,2),(3,4),(5,6)]
     print(val) # output - 3
 ```
 
-### \_single\_leading\_underscore
+### _single_leading_underscore
 
 This convention is used for declaring private variables, functions, methods and classes. Anything with this convention are ignored in `from module import *`.
 
-### single\_trailing\_underscore\_
+### single_trailing_underscore_
 
 This convention should be used for avoiding conflict with Python keywords or built-ins.
 
@@ -32,15 +32,15 @@ class_ = dict(n=50, boys=25, girls=25)
 # avoiding clash with the class keyword
 ```
 
-### \_\_double\_leading\_underscore
+### __double_leading_underscore
 
 Double underscore will mangle the attribute names of a class to avoid conflicts of attribute names between classes. Python will automatically add "\_ClassName" to the front of the attribute name which has a double underscore in front of it.
 
 [Read more](https://docs.python.org/3/tutorial/classes.html#private-variables)
 
-### \_\_double\_leading\_and\_trailing\_underscore\_\_
+### __double_leading_and_trailing_underscore\_\_
 
-This convention is used for special variables or \( magic \)methods  such as\_\_init\_\_, \_\_len\_\_. These methods provides special syntactic features.
+This convention is used for special variables or ( magic )methods  such as__init_\_, __len\__. These methods provides special syntactic features.
 
 ```
 class FileObject:

--- a/python/underscore.md
+++ b/python/underscore.md
@@ -1,6 +1,4 @@
-The underscore \(\_\) is used for just snake-case variables/functions in most programming languages but has special meaning in Python. 
-
-
+The underscore \(\_\)  has special meaning in Python.
 
 ### For ignoring values:
 
@@ -21,11 +19,9 @@ for _, val in list_of_tuples: # [(1,2),(3,4),(5,6)]
     print(val) # output - 3
 ```
 
-
-
 ### \_single\_leading\_underscore
 
-This convention is used for declaring private variables, functions, methods and classes. Anything with this convention are ignored in `from module import *`. 
+This convention is used for declaring private variables, functions, methods and classes. Anything with this convention are ignored in `from module import *`.
 
 ### single\_trailing\_underscore\_
 

--- a/python/underscore.md
+++ b/python/underscore.md
@@ -1,0 +1,59 @@
+The underscore \(\_\) is used for just snake-case variables/functions in most programming languages but has special meaning in Python. 
+
+
+
+### For ignoring values:
+
+If you do not need a specific value\(s\) while unpacking an object, just assign the value\(s\) to an underscore.
+
+```
+x, _, y = (1, 2, 3)
+
+# Ignore the multiple values. It is called "Extended Unpacking" which is available in only Python 3.x
+x, *_, y = (1, 2, 3, 4, 5) # x = 1, y = 5  
+
+# ignore the index
+for _ in range(10):     
+    task()  
+
+# Ignore a value of specific location
+for _, val in list_of_tuples: # [(1,2),(3,4),(5,6)]
+    print(val) # output - 3
+```
+
+
+
+### \_single\_leading\_underscore
+
+This convention is used for declaring private variables, functions, methods and classes. Anything with this convention are ignored in `from module import *`. 
+
+### single\_trailing\_underscore\_
+
+This convention should be used for avoiding conflict with Python keywords or built-ins.
+
+```
+class_ = dict(n=50, boys=25, girls=25)
+# avoiding clash with the class keyword
+```
+
+### \_\_double\_leading\_underscore
+
+Double underscore will mangle the attribute names of a class to avoid conflicts of attribute names between classes. Python will automatically add "\_ClassName" to the front of the attribute name which has a double underscore in front of it.
+
+[Read more](https://docs.python.org/3/tutorial/classes.html#private-variables)
+
+### \_\_double\_leading\_and\_trailing\_underscore\_\_
+
+This convention is used for special variables or \( magic \)methods  such as\_\_init\_\_, \_\_len\_\_. These methods provides special syntactic features.
+
+```
+class FileObject:
+    '''Wrapper for file objects to make sure the file gets closed on deletion.'''
+
+    def __init__(self, filepath='~', filename='sample.txt'):
+        # open a file filename in filepath in read and write mode
+        self.file = open(join(filepath, filename), 'r+')
+```
+
+[List of magic methods](https://github.com/RafeKettler/magicmethods/blob/master/magicmethods.pdf).
+

--- a/python/variable-naming.md
+++ b/python/variable-naming.md
@@ -1,10 +1,10 @@
-# Python Naming Convention &gt; Variable Naming
+# Python Naming Convention > Variable Naming
 
-## snake\_case
+## snake_case
 
 * Should be all in lowercase
-* Not begin with the special characters like e.g. & \(ampersand\), $ \(dollar\)
-* If the name contains multiple words, it should be separated by underscores \(\_\) e.g. json\_string
+* Not begin with the special characters like e.g. & (ampersand), $ (dollar)
+* If the name contains multiple words, it should be separated by underscores (_) e.g. json_string
 * Avoid one-character variables e.g. a, b
 
 ```python
@@ -18,7 +18,7 @@ class Student
 Python does not support privacy directly. This naming convention is used as a weak internal use indicator.
 
 * Should follow the above naming conventions
-* Should use a leading underscore \(\_\) to distinguish between "public" and "private" variables
+* Should use a leading underscore (_) to distinguish between "public" and "private" variables
 * For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
 
 ```

--- a/python/variable-naming.md
+++ b/python/variable-naming.md
@@ -15,7 +15,7 @@ class Student
 
 ## Private Variable
 
-Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
+Python does not support privacy directly. This naming convention is used as a weak internal use indicator.
 
 * Should follow the above naming conventions
 * Should use a leading underscore \(\_\) to distinguish between "public" and "private" variables

--- a/python/variable-naming.md
+++ b/python/variable-naming.md
@@ -1,15 +1,31 @@
-# Python Naming Convention > Variable Naming
+# Python Naming Convention &gt; Variable Naming
 
-## snake_case
-- Should be all in lowercase
-- Not begin with the special characters like e.g. & (ampersand), $ (dollar)
-- If the name contains multiple words, it should be separated by underscores (_) e.g. json_string
-- Avoid one-character variables e.g. a, b
+## snake\_case
 
+* Should be all in lowercase
+* Not begin with the special characters like e.g. & \(ampersand\), $ \(dollar\)
+* If the name contains multiple words, it should be separated by underscores \(\_\) e.g. json\_string
+* Avoid one-character variables e.g. a, b
 
 ```python
-class Student
+class Student
     age = None
-    _id = None
     ...
 ```
+
+## Private Variable
+
+Python does not support privacy directly. This naming convention is used as a weak internal use indicator only.
+
+* Should follow the above naming conventions
+* Should use a leading underscore \(\_\) to distinguish between "public" and "private" variables
+* For more read the [official python documentation](https://docs.python.org/2/tutorial/classes.html#private-variables-and-class-local-references). 
+
+```
+class Student:
+    age = None # public variable
+    _id = 0 # Private variable
+```
+
+
+


### PR DESCRIPTION
Edited /python/README.md
Added TL;DR table and a link to official Python naming conventions page.

Edited /python/variable-naming.md, /python/method-naming.md.
Added naming conventions for private/ non public methods/variables

New Files for:
Package Naming, Exception Naming, Uses of underscore in Python.