### PR TITLE
Removes bad link

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,7 +1,5 @@
 # Ruby Naming Convention
 
-The style guide for Ruby is based on [Guido’s ](https://www.Ruby.org/doc/essays/styleguide/)naming convention recommendations.
-
 List of covered sections:
 
 * [Class Naming](../Ruby/class-naming.md)


### PR DESCRIPTION
The reason the link is bad is I copied the section from python. I removed the link, as I did not base my style recommendations on an online style guide, but what I have seen in books, classes and tutorials.