### PR TITLE
Escape underscores to make it displayed correctly

### DIFF
--- a/python/underscore.md
+++ b/python/underscore.md
@@ -19,11 +19,11 @@ for _, val in list_of_tuples: # [(1,2),(3,4),(5,6)]
     print(val) # output - 3
 ```
 
-### \_single_leading_underscore
+### \_single\_leading\_underscore
 
 This convention is used for declaring private variables, functions, methods and classes. Anything with this convention are ignored in `from module import *`.
 
-### single_trailing_underscore_
+### single\_trailing\_underscore\_
 
 This convention should be used for avoiding conflict with Python keywords or built-ins.
 
@@ -32,13 +32,13 @@ class_ = dict(n=50, boys=25, girls=25)
 # avoiding clash with the class keyword
 ```
 
-### \__double_leading_underscore
+### \_\_double\_leading\_underscore
 
 Double underscore will mangle the attribute names of a class to avoid conflicts of attribute names between classes. Python will automatically add "\_ClassName" to the front of the attribute name which has a double underscore in front of it.
 
 [Read more](https://docs.python.org/3/tutorial/classes.html#private-variables)
 
-### \__double_leading_and_trailing_underscore\_\_
+### \_\_double_leading_and_trailing_underscore\_\_
 
 This convention is used for special variables or ( magic )methods  such as`__init__`, `__len__`. These methods provides special syntactic features.
 


### PR DESCRIPTION
Before the proposed change some underscores are not escaped properly, resulting in italic fonts rather than showing underscore literal