### PR TITLE
Fix link to constant naming on PHP page

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -1,7 +1,7 @@
 # PHP Naming Convention
 List of covered sections:
 * [Class Naming](../php/class-naming.md)
-* [Constant Naming](../php/constant-name.md)
+* [Constant Naming](../php/constant-naming.md)
 * [Interface Naming](../php/interface-naming.md)
 * [Method Naming](../php/method-naming.md)
 * [Variable Naming](../php/variable-naming.md)


### PR DESCRIPTION
Fixes a small issue on PHP naming convention page where clicking the constant naming link did nothing due to it being mistyped.