### PR TITLE
Fix typos in Git naming convention pages

### DIFF
--- a/git/commit-message-naming.md
+++ b/git/commit-message-naming.md
@@ -30,7 +30,7 @@ Access right management is used to check proper authorization to access an API b
 
 ## Conventional Commits
 
-Commit messages **MAY** use [Conventional Commits](https://www.conventionalcommits.org/en/) format. It provides guidelines to create a better commit history log, making easier to have automated tasks around it (e.g. automated changelogs). Commits would follow the format `<type>[optional scope]: <description>`, where `<type>` might be `feat`/`fix`/`chore`/`docs` etc. and breaking changes are indicated on the beginning of the optional body or footer section. 
+Commit messages **MAY** use [Conventional Commits](https://www.conventionalcommits.org/en/) format. It provides guidelines to create a better commit history log, making it easier to have automated tasks around it (e.g. automated changelogs). Commits would follow the format `<type>[optional scope]: <description>`, where `<type>` might be `feat`/`fix`/`chore`/`docs` etc. and breaking changes are indicated on the beginning of the optional body or footer section. 
 
 Example:
 ```
@@ -39,4 +39,4 @@ git commit -m "feat(survey): add nps survey to the home page
 BREAKING CHANGE:  `survey` objects in xml file have been re-used in the global configurations.
 ```
 
-Please refer to [Conventional Commits docs](https://www.conventionalcommits.org/en/) for more details
+Please refer to [Conventional Commits docs](https://www.conventionalcommits.org/en/) for more details.

--- a/git/pull-request-naming.md
+++ b/git/pull-request-naming.md
@@ -4,7 +4,7 @@ Consists of two parts:
 - Title: Short informative summary of the pull request
 - Description: More detailed explanatory text describing the PR for the reviewer
 
-## Subject:
+## Title:
 - Short and descriptive summary
 - Start with corresponding ticket/story id (e.g. from Jira, GitHub issue, etc.)
 - Should be capitalized and written in imperative present tense


### PR DESCRIPTION
Fix discrepancies in spelling and grammar; ensure consistent definitions