### PR TITLE
Update python underscore doc formatting.

### DIFF
--- a/python/underscore.md
+++ b/python/underscore.md
@@ -4,45 +4,45 @@ The underscore (\_)  has special meaning in Python.
 
 If you do not need a specific value(s) while unpacking an object, just assign the value(s) to an underscore.
 
-```
+```python
 x, _, y = (1, 2, 3)
 
 # Ignore the multiple values. It is called "Extended Unpacking" which is available in only Python 3.x
-x, *_, y = (1, 2, 3, 4, 5) # x = 1, y = 5  
+x, *_, y = (1, 2, 3, 4, 5) # x = 1, y = 5
 
 # ignore the index
-for _ in range(10):     
-    task()  
+for _ in range(10):
+    task()
 
 # Ignore a value of specific location
 for _, val in list_of_tuples: # [(1,2),(3,4),(5,6)]
     print(val) # output - 3
 ```
 
-### \_single\_leading\_underscore
+### _single_leading_underscore
 
 This convention is used for declaring private variables, functions, methods and classes. Anything with this convention are ignored in `from module import *`.
 
-### single\_trailing\_underscore\_
+### single_trailing_underscore_
 
 This convention should be used for avoiding conflict with Python keywords or built-ins.
 
-```
+```python
 class_ = dict(n=50, boys=25, girls=25)
 # avoiding clash with the class keyword
 ```
 
-### \_\_double\_leading\_underscore
+### __double_leading_underscore
 
 Double underscore will mangle the attribute names of a class to avoid conflicts of attribute names between classes. Python will automatically add "\_ClassName" to the front of the attribute name which has a double underscore in front of it.
 
 [Read more](https://docs.python.org/3/tutorial/classes.html#private-variables)
 
-### \_\_double_leading_and_trailing_underscore\_\_
+### __double_leading_and_trailing_underscore__
 
 This convention is used for special variables or ( magic )methods  such as`__init__`, `__len__`. These methods provides special syntactic features.
 
-```
+```python
 class FileObject:
     '''Wrapper for file objects to make sure the file gets closed on deletion.'''
 


### PR DESCRIPTION
- Changed code block syntax to specify Python language for better readability.
- Updated section headers to use consistent naming conventions (e.g., changed `_single_leading_underscore` to `_single_leading_underscore`).
- Minor formatting adjustments for improved clarity.

This resolves a rendering artefact where an unintended trailing backslash appeared in the documentation, see [namingconvention.org](https://namingconvention.org/python/underscore.html) screenshot:
<img width="1902" height="1070" alt="image" src="https://github.com/user-attachments/assets/1f5c2758-fc01-4818-aa1c-a33878409f5c" />
